### PR TITLE
Document support boundaries and public adoption guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Current published prebuilt targets:
 - macOS x64
 - Linux x64 (glibc)
 
-Windows native prebuilds are not included yet. On Windows, use WSL or build from source in a Rust toolchain environment.
+Windows native prebuilds are not included. On Windows, use WSL for install, build, and local Node query flows.
 
 If a prebuilt addon is unavailable for your platform, install from source in a Rust toolchain environment and run:
 
@@ -138,6 +138,8 @@ Use the docs by task:
 
 - [Getting Started](./docs/site/guides/getting-started.md)
 - [Choosing indexbind](./docs/site/guides/choosing-indexbind.md)
+- [Adoption Examples](./docs/site/guides/adoption-examples.md)
+- [Benchmarks and Case Studies](./docs/site/guides/benchmarks-and-case-studies.md)
 - [API Reference](./docs/site/reference/api.md)
 - [CLI Reference](./docs/site/reference/cli.md)
 - [Web and Cloudflare](./docs/site/guides/web-and-cloudflare.md)

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -53,6 +53,10 @@ If that decision is still unclear, go to [Choosing indexbind](./guides/choosing-
   [Getting Started](./guides/getting-started.md)
 - Want to decide whether it fits better than Pagefind, qmd, or Meilisearch:
   [Choosing indexbind](./guides/choosing-indexbind.md)
+- Want concrete integration shapes for docs, publishing, or local knowledge-base workflows:
+  [Adoption Examples](./guides/adoption-examples.md)
+- Want an indicative local baseline and current in-house usage patterns:
+  [Benchmarks and Case Studies](./guides/benchmarks-and-case-studies.md)
 - Want to integrate from code:
   [API](./reference/api.md)
 - Want to drive builds from the CLI:
@@ -65,13 +69,15 @@ If that decision is still unclear, go to [Choosing indexbind](./guides/choosing-
 ## Current Platform Support
 
 - Native prebuilds are published for macOS arm64, macOS x64, and Linux x64 (glibc).
-- Windows native prebuilds are not published yet.
+- Windows native prebuilds are not published; use WSL for install, build, and local Node query flows.
 - Canonical bundle runtimes work across browsers, Workers, and Cloudflare Workers.
 
 ## Docs Map
 
 - [Getting Started](./guides/getting-started.md)
 - [Choosing indexbind](./guides/choosing-indexbind.md)
+- [Adoption Examples](./guides/adoption-examples.md)
+- [Benchmarks and Case Studies](./guides/benchmarks-and-case-studies.md)
 - [Search Quality Controls](./guides/search-quality-controls.md)
 - [Web and Cloudflare](./guides/web-and-cloudflare.md)
 - [API](./reference/api.md)

--- a/docs/site/guides/README.md
+++ b/docs/site/guides/README.md
@@ -18,8 +18,14 @@ Use these pages when you want a working setup quickly.
 - [Getting Started](./getting-started.md)
   2026-03-25 · Install indexbind, build a native artifact and canonical bundle, and run your first query end to end.
 
+- [Adoption Examples](./adoption-examples.md)
+  2026-03-29 · Map indexbind onto docs, publishing, and local knowledge-base workflows without giving up host control.
+
 - [Web and Cloudflare](./web-and-cloudflare.md)
   2026-03-25 · Load canonical bundles in browsers, workers, and Cloudflare Workers.
+
+- [Benchmarks and Case Studies](./benchmarks-and-case-studies.md)
+  2026-03-29 · Review an indicative local baseline and the current in-house usage patterns behind indexbind.
 
 - [Search Quality Controls](./search-quality-controls.md)
   2026-03-26 · Understand which search options affect recall, reranking, filtering, and final ordering.

--- a/docs/site/guides/adoption-examples.md
+++ b/docs/site/guides/adoption-examples.md
@@ -1,0 +1,126 @@
+---
+title: Adoption Examples
+order: 15
+date: 2026-03-29
+summary: Map indexbind onto docs, publishing, and local knowledge-base workflows without giving up host control.
+---
+
+# Adoption Examples
+
+These examples show where `indexbind` fits in a larger system.
+
+The pattern is consistent across all of them:
+
+- the host application decides what the document set is
+- `indexbind` builds or updates retrieval artifacts
+- the host application still owns routing, filtering, ranking policy, and rendering
+
+## Docs Site With Browser Search
+
+Use this shape when you want a docs site to ship its search artifact with the site itself.
+
+Typical flow:
+
+1. build a canonical bundle from the docs corpus
+2. publish the bundle with the site
+3. load it in the browser or worker runtime
+
+```bash
+cargo run -p indexbind-build -- build-bundle ./docs ./public/index.bundle
+```
+
+```ts
+import { openWebIndex } from 'indexbind/web';
+
+const index = await openWebIndex('/index.bundle');
+const hits = await index.search('canonical bundle');
+```
+
+The host application still owns:
+
+- route generation
+- URL structure
+- snippet rendering
+- UI state and filters
+- any host-specific ranking rules layered on top
+
+This is close to how the `indexbind` documentation site is structured today.
+
+## Publishing or Blog System
+
+Use this shape when you already have a normalized content pipeline and want retrieval to stay inside that pipeline.
+
+Typical flow:
+
+1. parse frontmatter and markdown in the host application
+2. pass normalized documents into `indexbind/build`
+3. export the runtime artifact that matches the final deployment target
+
+```ts
+import {
+  buildCanonicalBundle,
+} from 'indexbind/build';
+
+await buildCanonicalBundle('./dist/search.bundle', [
+  {
+    relativePath: 'posts/retrieval.md',
+    canonicalUrl: '/posts/retrieval',
+    title: 'Retrieval Notes',
+    summary: 'How the publishing pipeline builds search artifacts.',
+    content: '# Retrieval Notes\n\nBuild artifacts during publish.',
+    metadata: {
+      section: 'blog',
+      visibility: 'public',
+    },
+  },
+], {
+  embeddingBackend: 'hashing',
+});
+```
+
+This shape works well when the host already owns:
+
+- frontmatter parsing
+- canonical URLs
+- taxonomies
+- publication state
+- product-specific ranking priors
+
+This is also a good fit when the blog or publishing system wants search to be one build output rather than a separate search service.
+
+## Local Knowledge Base or Agent Workspace
+
+Use this shape when documents change repeatedly and the host wants to trigger indexing incrementally.
+
+Typical flow:
+
+1. refresh the build cache
+2. export a fresh runtime artifact from that cache
+3. let the host tool open the new artifact locally
+
+```bash
+cargo run -p indexbind-build -- update-cache ./workspace-docs ./.indexbind-cache.sqlite --git-diff
+cargo run -p indexbind-build -- export-artifact ./.indexbind-cache.sqlite ./workspace.sqlite
+```
+
+```ts
+import { openIndex } from 'indexbind';
+
+const index = await openIndex('./workspace.sqlite');
+const hits = await index.search('incremental indexing');
+```
+
+This shape fits:
+
+- local knowledge bases with host-defined workflow
+- agent-driven documentation refreshes
+- git-hook or task-runner triggered rebuilds
+- products that want an embedded retrieval layer instead of a mutable local-store search product
+
+## Picking Between the Three
+
+- Prefer the docs-site pattern when the runtime target is browser or worker first.
+- Prefer the publishing pattern when the host already has a structured content pipeline.
+- Prefer the local knowledge-base pattern when incremental rebuilds and local Node queries matter more than browser distribution.
+
+If you need the full decision frame, go back to [Choosing indexbind](./choosing-indexbind.md). If you want indicative local measurements and current in-house usage notes, see [Benchmarks and Case Studies](./benchmarks-and-case-studies.md).

--- a/docs/site/guides/benchmarks-and-case-studies.md
+++ b/docs/site/guides/benchmarks-and-case-studies.md
@@ -1,0 +1,106 @@
+---
+title: Benchmarks and Case Studies
+order: 25
+date: 2026-03-29
+summary: Review an indicative local baseline and the current in-house usage patterns behind indexbind.
+---
+
+# Benchmarks and Case Studies
+
+This page is intentionally modest.
+
+It is not trying to prove that `indexbind` wins every search benchmark. It is here to show:
+
+- what a reproducible local baseline currently looks like
+- how large the current docs corpus is
+- which in-house usage patterns already rely on `indexbind`
+
+## Indicative Local Baseline
+
+These measurements were captured locally on a Darwin x86_64 development machine using the current `docs/site` corpus and the `hashing` embedding backend.
+
+Treat them as indicative rather than universal. Hardware, Rust target cache state, document shape, embedding backend, and reranking choices all affect the numbers.
+
+### Docs Site Baseline
+
+Corpus shape:
+
+- 14 markdown documents
+- 74 chunks
+- `hashing` backend
+- native SQLite artifact
+
+Observed local baseline:
+
+| Metric | Value |
+| --- | --- |
+| Build command | `target/debug/indexbind-build build docs/site <tmp>/docs-site.sqlite hashing` |
+| Build time | `0.07s` |
+| Artifact size | `352 KB` |
+| Query sample | 25 local Node searches with `hybrid: true` and `heuristic-v1` reranking |
+| Average query latency | `3.61 ms` |
+| Min / max query latency | `2.51 ms` / `5.28 ms` |
+
+This is the current "small real corpus" baseline for the project's own documentation set.
+
+### Regression Fixture Baseline
+
+The bundled regression fixture is intentionally tiny and should be read as a correctness baseline, not a throughput benchmark.
+
+Fixture shape:
+
+- 3 documents
+- 6 chunks
+- fixed query set in `fixtures/benchmark/basic/queries.json`
+
+Observed local baseline:
+
+| Metric | Value |
+| --- | --- |
+| Build + benchmark command | `npm run benchmark:basic` |
+| Benchmark result | `3 / 3` expected top hits passed |
+| End-to-end benchmark run time | `0.01s` for the benchmark step after artifact build |
+
+This fixture is useful for regression detection, CI confidence, and release checks. It is not meant to stand in for a large-corpus performance claim.
+
+## Current In-House Case Studies
+
+Current usage is still mostly first-party. That is fine at this stage, but it is worth stating plainly.
+
+### Documentation Site
+
+`indexbind` powers its own documentation story:
+
+- docs are a fixed markdown corpus
+- the corpus can be built into retrieval artifacts during publish
+- the host site still owns navigation, rendering, and information architecture
+
+This is the clearest public example of the docs-site/browser bundle path.
+
+### Blog and Publishing Flow
+
+`indexbind` is also used in a blog-style publishing flow where the host system owns:
+
+- frontmatter and canonical URL decisions
+- content routing
+- product-level ranking policy
+
+This is the clearest in-house example of the programmatic build path.
+
+### Local Knowledge Base and Workspace Search
+
+The project is also being used in a workspace-style local knowledge-base setting where:
+
+- incremental updates matter
+- agent or hook-triggered refreshes matter
+- the host wants a local retrieval layer rather than a full mutable local-store product
+
+This is the clearest in-house example of the incremental cache plus local Node artifact path.
+
+## How to Read These Results
+
+- The benchmark section is a local baseline, not a universal promise.
+- The case-study section shows the product boundary `indexbind` is optimized for.
+- The strongest current story is still "embedded retrieval for host-controlled systems", not "drop-in search for every environment".
+
+If you want concrete wiring examples, continue to [Adoption Examples](./adoption-examples.md).

--- a/docs/site/guides/getting-started.md
+++ b/docs/site/guides/getting-started.md
@@ -28,6 +28,8 @@ Supported prebuilt native targets:
 - macOS x64
 - Linux x64 (glibc)
 
+On Windows, use WSL for install, build, and local Node query flows. Native Windows prebuilds are not published.
+
 If your platform does not have a prebuilt native addon, build the native package locally in a Rust toolchain environment:
 
 ```bash

--- a/docs/site/reference/packaging.md
+++ b/docs/site/reference/packaging.md
@@ -14,6 +14,22 @@ The published npm release is split into:
 
 In normal use you install `indexbind` only. npm resolves the matching native package automatically when a supported prebuilt target exists.
 
+## Current Native Support
+
+Published native prebuilds currently cover:
+
+- macOS arm64
+- macOS x64
+- Linux x64 (glibc)
+
+Windows native prebuilds are not published. On Windows, use WSL for:
+
+- `npm install indexbind`
+- local build commands
+- local Node query flows that open SQLite artifacts through the native addon
+
+If a prebuilt package is unavailable for your environment, install and build in a Rust toolchain environment instead of assuming npm can resolve a matching native binary.
+
 ## What Ships in the npm Package
 
 The root package contains:
@@ -21,6 +37,8 @@ The root package contains:
 - runtime entrypoints such as `indexbind`, `indexbind/build`, `indexbind/web`, and `indexbind/cloudflare`
 - wasm runtime files in `dist/wasm` and `dist/wasm-bundler`
 - the native loader that resolves prebuilt platform packages when they exist
+
+The browser and worker entrypoints still come from the root package even when your host development machine is Windows. The current guidance is simply to do the install and build side inside WSL.
 
 ## What Ships in the Canonical Bundle
 


### PR DESCRIPTION
## Summary

This PR tightens the public release story in three areas:

- make the platform support boundary explicit, especially Windows via WSL
- add concrete adoption examples for docs, publishing, and local knowledge-base workflows
- add a modest benchmark and case-study page with indicative local baselines and current in-house usage notes

## Changes

- update `README.md` to clarify that Windows support currently goes through WSL for install, build, and local Node query flows
- update the docs landing page and packaging reference with the same support boundary
- add `Adoption Examples` under Guides
- add `Benchmarks and Case Studies` under Guides
- link the new pages from the main README and docs landing page

## Validation

- `npm run check`
- `npm run docs:index`
