### PR TITLE
Fix root package release contents for web runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,11 @@ jobs:
         env:
           RELEASE_VERSION: ${{ needs.verify.outputs.release_version }}
 
+      - name: Verify root package contents
+        run: npm run release:verify-root-package
+        env:
+          RELEASE_ROOT_DIR: ${{ github.workspace }}/release/npm/indexbind
+
       - name: Build smoke test artifact
         run: cargo run -p indexbind-build -- build fixtures/benchmark/basic/docs ${{ runner.temp }}/indexbind-smoke.sqlite hashing
 
@@ -168,6 +173,11 @@ jobs:
         run: npm run release:prepare-root
         env:
           RELEASE_VERSION: ${{ needs.verify.outputs.release_version }}
+
+      - name: Verify root package contents
+        run: npm run release:verify-root-package
+        env:
+          RELEASE_ROOT_DIR: ${{ github.workspace }}/release/npm/indexbind
 
       - name: Upload root package
         uses: actions/upload-artifact@v6

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test": "cargo test --workspace",
     "release:verify": "node scripts/verify-release.mjs",
     "release:prepare-root": "node scripts/prepare-root-package.mjs",
+    "release:verify-root-package": "node scripts/verify-root-package.mjs",
     "release:prepare-native": "node scripts/prepare-native-package.mjs",
     "release:smoke-install": "node scripts/smoke-install.mjs",
     "release:publish:github": "node scripts/publish-from-github-release.mjs"

--- a/scripts/prepare-root-package.mjs
+++ b/scripts/prepare-root-package.mjs
@@ -10,33 +10,10 @@ const outputDir = process.env.RELEASE_ROOT_DIR
   : path.resolve('release', 'npm', ROOT_PACKAGE_NAME);
 
 fs.rmSync(outputDir, { recursive: true, force: true });
-fs.mkdirSync(path.join(outputDir, 'dist', 'wasm'), { recursive: true });
-fs.mkdirSync(path.join(outputDir, 'dist', 'wasm-bundler'), { recursive: true });
+fs.mkdirSync(outputDir, { recursive: true });
+fs.cpSync(path.join(root, 'dist'), path.join(outputDir, 'dist'), { recursive: true });
 
-for (const relativePath of [
-  'dist/index.js',
-  'dist/index.d.ts',
-  'dist/native.js',
-  'dist/native.d.ts',
-  'dist/build.js',
-  'dist/build.d.ts',
-  'dist/web.js',
-  'dist/web.d.ts',
-  'dist/cloudflare.js',
-  'dist/cloudflare.d.ts',
-  'dist/wasm/indexbind_wasm.js',
-  'dist/wasm/indexbind_wasm.d.ts',
-  'dist/wasm/indexbind_wasm_bg.wasm',
-  'dist/wasm/indexbind_wasm_bg.wasm.d.ts',
-  'dist/wasm-bundler/indexbind_wasm.js',
-  'dist/wasm-bundler/indexbind_wasm.d.ts',
-  'dist/wasm-bundler/indexbind_wasm_bg.js',
-  'dist/wasm-bundler/indexbind_wasm_bg.wasm',
-  'dist/wasm-bundler/indexbind_wasm_bg.wasm.d.ts',
-  'README.md',
-  'LICENSE',
-  'CHANGELOG.md',
-]) {
+for (const relativePath of ['README.md', 'LICENSE', 'CHANGELOG.md']) {
   fs.copyFileSync(path.join(root, relativePath), path.join(outputDir, relativePath));
 }
 

--- a/scripts/verify-root-package.mjs
+++ b/scripts/verify-root-package.mjs
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { ROOT_PACKAGE_NAME } from './release-targets.mjs';
+
+const packageDir = process.env.RELEASE_ROOT_DIR
+  ? path.resolve(process.env.RELEASE_ROOT_DIR)
+  : path.resolve('release', 'npm', ROOT_PACKAGE_NAME);
+
+const requiredFiles = [
+  'package.json',
+  'README.md',
+  'LICENSE',
+  'CHANGELOG.md',
+  'dist/index.js',
+  'dist/index.d.ts',
+  'dist/build.js',
+  'dist/build.d.ts',
+  'dist/native.js',
+  'dist/native.d.ts',
+  'dist/web.js',
+  'dist/web.d.ts',
+  'dist/web-core.js',
+  'dist/web-core.d.ts',
+  'dist/cloudflare.js',
+  'dist/cloudflare.d.ts',
+  'dist/cloudflare/worker.mjs',
+  'dist/wasm/indexbind_wasm.js',
+  'dist/wasm/indexbind_wasm.d.ts',
+  'dist/wasm/indexbind_wasm_bg.wasm',
+  'dist/wasm/indexbind_wasm_bg.wasm.d.ts',
+  'dist/wasm-bundler/indexbind_wasm.js',
+  'dist/wasm-bundler/indexbind_wasm.d.ts',
+  'dist/wasm-bundler/indexbind_wasm_bg.js',
+  'dist/wasm-bundler/indexbind_wasm_bg.wasm',
+  'dist/wasm-bundler/indexbind_wasm_bg.wasm.d.ts',
+];
+
+for (const relativePath of requiredFiles) {
+  const absolutePath = path.join(packageDir, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Prepared root package is missing required file: ${relativePath}`);
+  }
+}
+
+for (const relativePath of collectFiles(path.join(packageDir, 'dist'))) {
+  if (!relativePath.endsWith('.js') && !relativePath.endsWith('.d.ts') && !relativePath.endsWith('.mjs')) {
+    continue;
+  }
+
+  const absolutePath = path.join(packageDir, relativePath);
+  const content = fs.readFileSync(absolutePath, 'utf8');
+
+  for (const specifier of collectRelativeSpecifiers(content)) {
+    const target = path.resolve(path.dirname(absolutePath), specifier);
+    if (!fs.existsSync(target)) {
+      throw new Error(
+        `Prepared root package import target is missing: ${relativePath} -> ${specifier}`,
+      );
+    }
+  }
+}
+
+console.log(`Verified prepared root package at ${packageDir}`);
+
+function collectFiles(directory) {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(absolutePath));
+      continue;
+    }
+    files.push(path.relative(packageDir, absolutePath));
+  }
+
+  return files;
+}
+
+function collectRelativeSpecifiers(content) {
+  const specifiers = new Set();
+  const patterns = [
+    /\bfrom\s+['"](\.{1,2}\/[^'"]+)['"]/g,
+    /\bimport\s*\(\s*['"](\.{1,2}\/[^'"]+)['"]\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of content.matchAll(pattern)) {
+      specifiers.add(match[1]);
+    }
+  }
+
+  return [...specifiers];
+}


### PR DESCRIPTION
Closes #21

## Summary
- fix `release:prepare-root` to copy the full `dist/` tree instead of a hand-maintained file allowlist
- add `release:verify-root-package` to catch missing files and broken relative imports in the prepared root package
- run the new root-package verification in both release packaging jobs before tarballs are uploaded

## Verification
- `npm run build`
- `npm run release:prepare-root`
- `RELEASE_ROOT_DIR=$PWD/release/npm/indexbind npm run release:verify-root-package`
- packed the prepared root package and imported `dist/web.js` from a temp install to confirm `web-core.js` is present
- `npm run check`
